### PR TITLE
added support for aes 256 (fixed key size bug) and SHA512

### DIFF
--- a/lib/ooxml_decrypt/encrypted_key.rb
+++ b/lib/ooxml_decrypt/encrypted_key.rb
@@ -37,7 +37,7 @@ module OoxmlDecrypt
       end
 
       temp = hash(temp + ENCRYPTED_KEY_VALUE_BLOCK_KEY)
-      temp.pad_or_trim!( @block_size )
+      temp.pad_or_trim!( @key_bits/8 )
     end
     private :key_encryption_key
 

--- a/lib/ooxml_decrypt/key_info_base.rb
+++ b/lib/ooxml_decrypt/key_info_base.rb
@@ -32,6 +32,8 @@ module OoxmlDecrypt
       case @hash_algorithm
       when "SHA1"
         Digest::SHA1.digest(value)
+      when "SHA512"
+        Digest::SHA512.digest(value)
       else
         raise "Unsupported hash algorithm: #{@hash_algorithm}"
       end


### PR DESCRIPTION
Hi there, 

There was a slight bug with the pad_or_trim of the encryption key. The key size in bytes is key_bits/8 and not block_size. For AES128 both happen to bit 16 bytes, but in order to support AES256 the key size has to be calculated properly

The support for SHA512 is straight forward. 

 regards, 

   Philippe Oechslin  
