### PR TITLE
Bundler, executable and README updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ Gemfile.lock
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# rspec failure tracking
+.rspec_status

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
+---
+sudo: false
 language: ruby
+cache: bundler
 rvm:
 - 2.4
 - 2.5
 - 2.6
-script: bundle exec rspec spec
+before_install: gem install bundler -v 2.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## [Unreleased]
+*no unreleased changes*
+
+## 1.0.0 / 2019-05-08
+### Added
+* Added Installation and Usage instructions to the README
+
+### Changed
+* Moved the executable, removing the .rb file extention and added a shebang

--- a/README.md
+++ b/README.md
@@ -1,9 +1,59 @@
-# ooxml_decrypt [![Build Status](https://travis-ci.org/woodbusy/ooxml_decrypt.svg?branch=master)](https://travis-ci.org/woodbusy/ooxml_decrypt)
+# OoxmlDecrypt [![Build Status](https://travis-ci.org/woodbusy/ooxml_decrypt.svg?branch=master)](https://travis-ci.org/woodbusy/ooxml_decrypt)
 
 A Ruby library and script for decrypting password-protected Microsoft Office XML files (.docx, .xlsx, etc.), which use the OOXML format. There are many tools available for working with OOXML files without Office, but a password-protected document typically requires an Office installation to decrypt. This pure-Ruby, standalone library and script can decrypt Office files without an Office installation.
 
 At present, this only supports documents encrypted (i.e. password-protected) by Office 2010 or later. Office 2007 also uses XML, but the encryption settings are a bit different.
 
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'ooxml_decrypt'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install ooxml_decrypt
+
+## Usage
+
+### Command Line Tool
+
+If you installed the gem using Bundler, execute:
+
+    $ bundle exec ooxml_decrypt --source <path> --destination <path> --password <password>
+
+otherwise use:
+
+    $ ooxml_decrypt --source <path> --destination <path> --password <password>
+
+### Within your code
+
+To decrypt a file programatically:
+
+```ruby
+require 'ooxml_decrypt'
+
+encrypted_path = ...
+decrypted_path = ...
+# Ensure password is a binary representation of a UTF-16LE string
+binary_password = password.encode("utf-16le")
+                          .bytes.pack("c*")
+                          .encode("binary")
+
+OoxmlDecrypt::EncryptedFile.decrypt_to_file(encrypted_path, binary_password, decrypted_path)
+```
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'ooxml_decrypt'
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require 'pry'
+# Pry.start
+
+require 'irb'
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/exe/decrypt_ooxml
+++ b/exe/decrypt_ooxml
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + "/../lib"))
 
 require "ooxml_decrypt"

--- a/lib/ooxml_decrypt.rb
+++ b/lib/ooxml_decrypt.rb
@@ -1,3 +1,4 @@
 require "ooxml_decrypt/key_data"
 require "ooxml_decrypt/encrypted_key"
 require "ooxml_decrypt/encrypted_file"
+require "ooxml_decrypt/version"

--- a/lib/ooxml_decrypt/version.rb
+++ b/lib/ooxml_decrypt/version.rb
@@ -1,4 +1,4 @@
 # This stores the current version of the OoxmlDecrypt gem
 module OoxmlDecrypt
-  VERSION = '0.1.0'.freeze
+  VERSION = '1.0.0'.freeze
 end

--- a/lib/ooxml_decrypt/version.rb
+++ b/lib/ooxml_decrypt/version.rb
@@ -1,0 +1,4 @@
+# This stores the current version of the OoxmlDecrypt gem
+module OoxmlDecrypt
+  VERSION = '0.1.0'.freeze
+end

--- a/ooxml_decrypt.gemspec
+++ b/ooxml_decrypt.gemspec
@@ -11,11 +11,14 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/woodbusy/ooxml_decrypt'
   spec.license = 'Apache-2.0'
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |s| s =~ %r{^pkg/} }
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(bin|spec)/}) }
+  end
   spec.files -= %w[.travis.yml] # Not needed in the gem
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
   spec.add_dependency 'nokogiri', '~> 1.10'

--- a/ooxml_decrypt.gemspec
+++ b/ooxml_decrypt.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'nokogiri'
-  spec.add_dependency 'ruby-ole'
+  spec.add_dependency 'nokogiri', '~> 1.10'
+  spec.add_dependency 'ruby-ole', '~> 1.2'
 
   spec.add_development_dependency 'rspec', '>= 2.11.0', '< 4.0'
 end

--- a/ooxml_decrypt.gemspec
+++ b/ooxml_decrypt.gemspec
@@ -17,5 +17,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'nokogiri', '~> 1.10'
   spec.add_dependency 'ruby-ole', '~> 1.2'
 
+  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '>= 2.11.0', '< 4.0'
 end

--- a/ooxml_decrypt.gemspec
+++ b/ooxml_decrypt.gemspec
@@ -9,7 +9,8 @@ Gem::Specification.new do |spec|
 
   spec.files = `git ls-files -z`.split("\x0").reject { |s| s =~ %r{^pkg/} }
   spec.files -= %w[.travis.yml] # Not needed in the gem
-  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.bindir        = 'exe'
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 

--- a/ooxml_decrypt.gemspec
+++ b/ooxml_decrypt.gemspec
@@ -1,6 +1,10 @@
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "ooxml_decrypt/version"
+
 Gem::Specification.new do |spec|
   spec.name = 'ooxml_decrypt'
-  spec.version = '0.1.0'
+  spec.version = OoxmlDecrypt::VERSION
   spec.authors = %w[woodbusy phish]
   spec.summary = 'Ruby library and script for decrypting password-protected ' \
                  'Microsoft Office XML files (.docx, .xlsx, etc.)'

--- a/spec/crypto_spec.rb
+++ b/spec/crypto_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 module OoxmlDecrypt
-  describe "When testing decryption" do
+  RSpec.describe "When testing decryption" do
     let(:encrypted_key) do
       EncryptedKey.new( :spin_count => 100_000,
                         :block_size => 16,

--- a/spec/encrypted_file_spec.rb
+++ b/spec/encrypted_file_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 module OoxmlDecrypt
-  describe EncryptedFile do
+  RSpec.describe EncryptedFile do
     it "should decrypt an encrypted XLSX" do
       password = "p\0a\0s\0s\0w\0o\0r\0d\0"
       filename = "spec/examples/password.xlsx"

--- a/spec/ooxml_decrypt_spec.rb
+++ b/spec/ooxml_decrypt_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe OoxmlDecrypt do
+  it 'has a version number' do
+    expect(OoxmlDecrypt::VERSION).not_to be nil
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,15 @@
+require "bundler/setup"
 require "ooxml_decrypt"
 require "ooxml_decrypt/string_helpers"
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
Key changes are the addition of installation and usage documentation in the README and the breaking change that you must now use the command line script without the `.rb` extension (hence the major version bump). Once you install the gem, the `ooxml_decrypt` script is available at the CI. Other housekeeping updates the gem for use with Bundler and Rake.